### PR TITLE
Add Firewall Rules to Fix LXD in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,8 @@ jobs:
       - name: Install rockcraft
         run: |
           sudo snap install --classic --channel edge rockcraft
+          sudo iptables -F FORWARD
+          sudo iptables -P FORWARD ACCEPT
       - name: Build ROCK
         run: rockcraft pack --verbose
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,10 +11,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Setup LXD
-        uses: whywaita/setup-lxd@v1
-        with:
-          lxd_version: latest/stable
-
+        uses: canonical/setup-lxd
       - name: Install rockcraft
         run: |
           sudo snap install --classic --channel edge rockcraft

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Setup LXD
-        uses: canonical/setup-lxd
+        uses: canonical/setup-lxd@main
       - name: Install rockcraft
         run: |
           sudo snap install --classic --channel edge rockcraft

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,8 +15,6 @@ jobs:
       - name: Install rockcraft
         run: |
           sudo snap install --classic --channel edge rockcraft
-          sudo iptables -F FORWARD
-          sudo iptables -P FORWARD ACCEPT
       - name: Build ROCK
         run: rockcraft pack --verbose
 


### PR DESCRIPTION
There is an issue with `ubuntu-latest` that broke the ability for LXD containers to reach the external network.  This in turn broke rockcraft and the build process.  This same issue is seen in other rockcraft repos.