### PR TITLE
Update rockcraft metadata to match included license

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,3 +1,5 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
 name: mongodb # the name of your ROCK
 base: ubuntu:22.04 # the base environment for this ROCK
 version: '5.0' # just for humans. Semantic versioning is recommended

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -7,7 +7,7 @@ description: |
     document-oriented database program. Classified 
     as a NoSQL database program, MongoDB uses JSON
     -like documents with optional schemas.
-license: SSPL-1.0 # your application's SPDX license
+license: Apache-2.0 # your application's SPDX license
 cmd: [/usr/bin/mongod]
 platforms: # The platforms this ROCK should be built on and run on
     amd64:


### PR DESCRIPTION
The incorrect license was listed in the rockcraft metadata which is fixed in this PR.  The license field now reflects the included Apache 2 license.