### PR TITLE
Convert rock to use snap base

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -23,34 +23,18 @@ platforms: # The platforms this ROCK should be built on and run on
     amd64:
 
 parts:
-    mongo-repo:
+    mongo-snap:
         plugin: nil
-        override-pull: |
-            apt update
-            apt install -y wget lsb-release
-            wget https://repo.percona.com/apt/percona-release_latest.$(\
-                lsb_release \-sc)_all.deb
-            dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
-            percona-release enable psmdb-50 release
-            percona-release enable pbm release
-            apt update
-        override-build: |
-            mkdir -p $CRAFT_PART_INSTALL/data/db
-    mongo-deb:
+        stage-snaps:
+            - charmed-mongodb/5.0/edge
+    dep-debs:
         plugin: nil
-        after: [mongo-repo]
         stage-packages:
-            - percona-server-mongodb
-            - percona-server-mongodb-shell
-            - percona-backup-mongodb
             - util-linux
     non-root-user:
         plugin: nil
-        after: [mongo-deb]
+        after: [mongo-snap]
         overlay-script: |
             # Create a user in the $CRAFT_OVERLAY chroot
             groupadd -R $CRAFT_OVERLAY -g 1000 mongodb
             useradd -R $CRAFT_OVERLAY -M -r -g mongodb -u 1000 mongodb
-        override-prime: |
-            craftctl default
-            chown -R 1000:1000 data

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -27,14 +27,6 @@ parts:
         plugin: nil
         stage-snaps:
             - charmed-mongodb/5.0/edge
-        override-prime: |
-            craftctl default
-            export SNAP=$CRAFT_STAGE
-            export SNAP_COMMON=$CRAFT_PRIME/var/snap/charmed-mongodb/common
-            export SNAP_DATA=$CRAFT_PRIME/var/snap/charmed-mongodb/current
-            mkdir -p $SNAP_COMMON
-            mkdir -p $SNAP_DATA
-            $CRAFT_PRIME/snap.charmed-mongodb/hooks/install
     dep-debs:
         plugin: nil
         stage-packages:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -32,6 +32,7 @@ parts:
         stage-packages:
             - util-linux
             - libssh-4
+            - libbrotli1
     non-root-user:
         plugin: nil
         after: [mongo-snap]

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -27,6 +27,14 @@ parts:
         plugin: nil
         stage-snaps:
             - charmed-mongodb/5.0/edge
+        override-prime: |
+            craftctl default
+            export SNAP=$CRAFT_STAGE
+            export SNAP_COMMON=$CRAFT_PRIME/var/snap/charmed-mongodb/common
+            export SNAP_DATA=$CRAFT_PRIME/var/snap/charmed-mongodb/current
+            mkdir -p $SNAP_COMMON
+            mkdir -p $SNAP_DATA
+            $CRAFT_PRIME/snap.charmed-mongodb/hooks/configure
     dep-debs:
         plugin: nil
         stage-packages:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -18,7 +18,7 @@ cmd:
     - --regid
     - mongodb
     - --
-    - /snap/bin/charmed-mongodb.mongod
+    - /usr/bin/mongod
 platforms: # The platforms this ROCK should be built on and run on
     amd64:
 

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -34,7 +34,7 @@ parts:
             export SNAP_DATA=$CRAFT_PRIME/var/snap/charmed-mongodb/current
             mkdir -p $SNAP_COMMON
             mkdir -p $SNAP_DATA
-            $CRAFT_PRIME/snap.charmed-mongodb/hooks/configure
+            $CRAFT_PRIME/snap.charmed-mongodb/hooks/install
     dep-debs:
         plugin: nil
         stage-packages:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -31,6 +31,7 @@ parts:
         plugin: nil
         stage-packages:
             - util-linux
+            - libssh-4
     non-root-user:
         plugin: nil
         after: [mongo-snap]

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -18,7 +18,7 @@ cmd:
     - --regid
     - mongodb
     - --
-    - /usr/bin/mongod
+    - /snap/bin/charmed-mongodb.mongod
 platforms: # The platforms this ROCK should be built on and run on
     amd64:
 

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -44,5 +44,5 @@ parts:
         after: [mongo-snap]
         overlay-script: |
             # Create a user in the $CRAFT_OVERLAY chroot
-            groupadd -R $CRAFT_OVERLAY -g 1000 mongodb
-            useradd -R $CRAFT_OVERLAY -M -r -g mongodb -u 1000 mongodb
+            groupadd -R $CRAFT_OVERLAY -g  584788 mongodb
+            useradd -R $CRAFT_OVERLAY -M -r -g mongodb -u 584788 mongodb


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Base change

* **What is the current behavior?** (You can also link to an open issue here)
All mongodb components are installed from percona-provided deb packages.

* **What is the new behavior (if this is a feature change)?**
The rock is now built using the `charmed-mongodb` snap instead of the official deb packages.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes, you'll likely have to rewrite quite a few things to deal with confinement.

* **Other information**:
[charmed-mongodb-snap repo](https://github.com/canonical/charmed-mongodb-snap)
