### PR TITLE
Trigger beta release job for the first time from CI

### DIFF
--- a/.github/workflows/publish_beta.yaml
+++ b/.github/workflows/publish_beta.yaml
@@ -1,5 +1,8 @@
 name: Publish ROCK (beta)
-on: workflow_dispatch
+on:
+  push:
+    branches:
+      - '6-22.04'
 
 jobs:
   build:


### PR DESCRIPTION
## About

To make workflow for publishing beta visible in actions it needs to be triggered once