### PR TITLE
Fix release pipeline of Rock

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,28 +1,77 @@
-# Copyright 2024 Canonical Ltd.
-# See LICENSE file for licensing details.
-name: Release to GHCR
+name: Publish to GHCR
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+env:
+  RELEASE: edge
 
 on:
   push:
     branches:
-      - 6-22.04
-  workflow_dispatch:
+      - main
 
 jobs:
-  build:
-    name: Build rock
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v16
+  ci-tests:
+    name: Build and Run Tests
+    uses: ./.github/workflows/ci.yaml
 
-  release:
-    name: Release rock
+  publish:
+    name: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs:
-      - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_rock.yaml@v16
-    with:
-      artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
-    permissions:
-      packages: write # Needed to publish to GitHub Container Registry
+      - ci-tests
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Install required dependencies
+        run: |
+          # docker
+          sudo snap install docker
+          sudo addgroup --system docker; sudo adduser $USER docker
+          newgrp docker
+          sudo snap disable docker; sudo snap enable docker
+
+          # skopeo
+          sudo snap install --devmode --channel edge skopeo
+
+          # yq
+          sudo snap install yq
+
+      - name: Download rock file
+        uses: actions/download-artifact@v3
+        with:
+          name: charmed_mongodb_rock_amd64
+          path: .
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USER }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Publish rock to Store
+        run: |
+          version="$(cat rockcraft.yaml | yq .version)"
+
+          base="$(cat rockcraft.yaml | yq .base)"
+          base="${base#*:}"
+
+          # push major version to edge
+          major_tag_version="${version%%.*}-${{ env.RELEASE }}"
+          sudo skopeo \
+              --insecure-policy \
+              copy \
+              oci-archive:charmed-mongodb_${version}_amd64.rock \
+              docker-daemon:ghcr.io/canonical/charmed-mongodb:${major_tag_version}
+          docker push ghcr.io/canonical/charmed-mongodb:${major_tag_version}
+
+          ### push full version to edge
+          tag_version="${version}-${base}_${{ env.RELEASE }}"
+          echo "Publishing charmed-mongodb:${tag_version}"
+          sudo skopeo \
+              --insecure-policy \
+              copy \
+              oci-archive:charmed-mongodb_${version}_amd64.rock \
+              docker-daemon:ghcr.io/canonical/charmed-mongodb:${tag_version}
+          docker push ghcr.io/canonical/charmed-mongodb:${tag_version}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,11 +3,15 @@ name: Publish to GHCR
 env:
   RELEASE: edge
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
-  pull_request:
   push:
     branches:
       - 6-22.04
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,6 +10,10 @@ on:
       - 6-22.04
 
 jobs:
+  build:
+    name: Build rock
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v16
+
   publish:
     needs: build
     name: publish

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,9 +37,11 @@ jobs:
           # yq
           sudo snap install yq
 
-      - uses: actions/download-artifact@v3
+      - name: Download rock package(s)
+        uses: actions/download-artifact@v4
         with:
-          name: mongodb-rock
+          pattern: ${{ needs.build.outputs.artifact-prefix }}-*
+          merge-multiple: true
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -55,7 +55,7 @@ jobs:
           full_version="$(cat rockcraft.yaml | yq .version)"
           version="${full_version%-*}"
           base="$(cat rockcraft.yaml | yq .base)"
-          base="${base#*:}"
+          base="${base#*@}"
 
           # push major version to edge
           major_tag_version="${version%%.*}-${{ env.RELEASE }}"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -52,8 +52,8 @@ jobs:
 
       - name: Publish rock to Store
         run: |
-          version="$(cat rockcraft.yaml | yq .version)"
-          version="${version%-*}"
+          full_version="$(cat rockcraft.yaml | yq .version)"
+          version="${full_version%-*}"
           base="$(cat rockcraft.yaml | yq .base)"
           base="${base#*:}"
 
@@ -62,7 +62,7 @@ jobs:
           sudo skopeo \
               --insecure-policy \
               copy \
-              oci-archive:charmed-mongodb_${version}_amd64.rock \
+              oci-archive:charmed-mongodb_${full_version}_amd64.rock \
               docker-daemon:ghcr.io/canonical/charmed-mongodb:${major_tag_version}
           docker push ghcr.io/canonical/charmed-mongodb:${major_tag_version}
 
@@ -72,6 +72,6 @@ jobs:
           sudo skopeo \
               --insecure-policy \
               copy \
-              oci-archive:charmed-mongodb_${version}_amd64.rock \
+              oci-archive:charmed-mongodb_${full_version}_amd64.rock \
               docker-daemon:ghcr.io/canonical/charmed-mongodb:${tag_version}
           docker push ghcr.io/canonical/charmed-mongodb:${tag_version}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   publish:
+    needs: build
     name: publish
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -32,11 +33,9 @@ jobs:
           # yq
           sudo snap install yq
 
-      - name: Download rock file
-        uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v3
         with:
-          name: charmed_mongodb_rock_amd64
-          path: .
+          name: mongodb-rock
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -48,7 +47,7 @@ jobs:
       - name: Publish rock to Store
         run: |
           version="$(cat rockcraft.yaml | yq .version)"
-
+          version="${version%-*}"
           base="$(cat rockcraft.yaml | yq .base)"
           base="${base#*:}"
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,9 +4,10 @@ env:
   RELEASE: edge
 
 on:
+  pull_request:
   push:
     branches:
-      - main
+      - 6-22.04
 
 jobs:
   publish:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,16 +9,10 @@ on:
       - main
 
 jobs:
-  ci-tests:
-    name: Build and Run Tests
-    uses: ./.github/workflows/ci.yaml
-
   publish:
     name: publish
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs:
-      - ci-tests
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR removes the usage of the DP workflows step for rock publishing - which was failing. And implements it manually instead.