### PR TITLE
feat: start scripts for mongodb and mongos

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,4 +6,4 @@ on:
 jobs:
   build:
     name: Build rock
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v16
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v29.0.1

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -53,7 +53,6 @@ jobs:
           pipx install poetry
           pipx install charmcraftcache
           pipx inject poetry poetry-plugin-export
-          poetry config warnings.export false
       - name: Integration Tests
         run: |
           sg snap_microk8s -c "tox -e ${{ matrix.env }}"

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -31,10 +31,10 @@ jobs:
           provider: microk8s
           channel: "1.29-strict/stable"
           bootstrap-constraints: "cores=2 mem=2G"
-          juju-channel: 3.4/stable
+          juju-channel: 3.6/stable
           # This is needed until
           # https://bugs.launchpad.net/juju/+bug/1977582 is fixed
-          bootstrap-options: "--agent-version 3.4.4"
+          bootstrap-options: "--agent-version 3.6.1"
       - name: Install rockcraft
         run: |
           sudo snap install rockcraft --classic

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -35,6 +35,7 @@ jobs:
           # This is needed until
           # https://bugs.launchpad.net/juju/+bug/1977582 is fixed
           bootstrap-options: "--agent-version 3.6.1"
+          charmcraft-channel: "latest/candidate"
       - name: Install rockcraft
         run: |
           sudo snap install rockcraft --classic

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: Build rock
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v16
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v29.0.1
 
   integration:
     runs-on: [self-hosted, linux, X64, jammy, large]

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   build:
     name: Build rock
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v16
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v29.0.1
 
   publish:
     needs: build

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -74,5 +74,9 @@ parts:
     source: scripts
     organize:
       start.sh: bin/start.sh
+      start-mongod.sh: bin/start-mongod.sh
+      start-mongos.sh: bin/start-mongos.sh
     stage:
       - bin/start.sh
+      - bin/start-mongod.sh
+      - bin/start-mongos.sh

--- a/scripts/start-mongod.sh
+++ b/scripts/start-mongod.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec /usr/bin/mongod ${MONGOD_ARGS}

--- a/scripts/start-mongos.sh
+++ b/scripts/start-mongos.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec /usr/bin/mongos ${MONGOS_ARGS}


### PR DESCRIPTION
This PR adds two scripts for starting mongod and mongos using an environment variable to provide the parameters.

This is specifically useful in order to bring unity between snap and rock for the new single kernel charms.