### PR TITLE
[DPE-6365] add trivy to github workflow

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -1,0 +1,77 @@
+name: trivy
+on:
+  push:
+    branches:
+      - 6-22.04
+      - 5-22.04
+  pull_request:
+  workflow_call:
+    inputs:
+      branch:
+        type: string
+        default: ""
+jobs:
+  build:
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v29.0.1
+  scan:
+    name: Trivy scan and sbom generation
+    needs: build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Install rockcraft (for skopeo)
+        run: |
+          sudo snap install rockcraft --classic --edge
+      - name: Get Artifact Name
+        id: artifact
+        run: |
+          BASE_ARTIFACT=$(make help | grep 'Artifact: ')
+          echo "base_artifact_name=${BASE_ARTIFACT#'Artifact: '}" >> $GITHUB_OUTPUT
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: charmed-mongodb
+          path: charmed-mongodb
+      - name: Import locally
+        run: |
+          # Unpack artifact
+          mv charmed-mongodb/${{ steps.artifact.outputs.base_artifact_name }} .
+          sudo rockcraft.skopeo --insecure-policy copy \
+            docker-archive:${{ steps.artifact.outputs.base_artifact_name }} \
+            docker-daemon:trivy/charmed-mongodb:test
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: "trivy/charmed-mongodb:test"
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "MEDIUM,HIGH,CRITICAL"
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        if: always()
+        with:
+          sarif_file: "trivy-results.sarif"
+          ref: ${{ inputs.branch }}
+
+      - name: Run Trivy in GitHub SBOM mode and submit results to Dependency Graph
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: "image"
+          format: "spdx-json"
+          output: "dependency-results.sbom.json"
+          image-ref: "trivy/charmed-mongodb:test"
+          github-pat: ${{ secrets.GITHUB_TOKEN }}
+          severity: "MEDIUM,HIGH,CRITICAL"
+          scanners: "vuln"
+
+      - name: Upload trivy report as a Github artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-sbom-report
+          path: "${{ github.workspace }}/dependency-results.sbom.json"
+          retention-days: 90

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -24,6 +24,9 @@ jobs:
 
       - name: Install required dependencies
         run: |
+          # rockcraft
+          sudo snap install rockcraft --classic --edge
+
           # docker
           sudo snap install docker
           sudo addgroup --system docker; sudo adduser $USER docker
@@ -45,11 +48,13 @@ jobs:
       - name: Import locally
         run: |
           full_version="$(cat rockcraft.yaml | yq .version)"
-          sudo skopeo \
-              --insecure-policy \
+          ls
+
+          sudo rockcraft.skopeo   --insecure-policy \
               copy \
-              oci-archive:charmed-mongodb_${full_version}_amd64.rock \
+              oci-archive:charmed-mongodb_6.0.6-2_amd64.rock \
               docker-daemon:trivy/charmed-mongodb:test
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.28.0
         with:

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -23,15 +23,11 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
 
-      - name: Install rockcraft (for skopeo)
+      - name: Install snaps
         run: |
           sudo snap install rockcraft --classic --edge
-      - name: Get Artifact Name
-        id: artifact
-        run: |
+          sudo snap install --devmode --channel edge skopeo
           sudo snap install yq
-          BASE_ARTIFACT="$(cat rockcraft.yaml | yq .name)"
-          echo "base_artifact_name=${BASE_ARTIFACT#'Artifact: '}" >> $GITHUB_OUTPUT
       - name: Download rock package(s)
         uses: actions/download-artifact@v4
         with:
@@ -39,11 +35,12 @@ jobs:
           merge-multiple: true
       - name: Import locally
         run: |
-          # Unpack artifact
-          mv charmed-mongodb/${{ steps.artifact.outputs.base_artifact_name }} .
-          sudo rockcraft.skopeo --insecure-policy copy \
-            docker-archive:${{ steps.artifact.outputs.base_artifact_name }} \
-            docker-daemon:trivy/charmed-mongodb:test
+          full_version="$(cat rockcraft.yaml | yq .version)"
+          sudo skopeo \
+              --insecure-policy \
+              copy \
+              oci-archive:charmed-mongodb_${full_version}_amd64.rock \
+              docker-daemon:trivy/charmed-mongodb:test
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.28.0
         with:

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -32,11 +32,11 @@ jobs:
           sudo snap install yq
           BASE_ARTIFACT="$(cat rockcraft.yaml | yq .name)"
           echo "base_artifact_name=${BASE_ARTIFACT#'Artifact: '}" >> $GITHUB_OUTPUT
-      - name: Download artifact
+      - name: Download rock package(s)
         uses: actions/download-artifact@v4
         with:
-          name: charmed-mongodb
-          path: charmed-mongodb
+          pattern: ${{ needs.build.outputs.artifact-prefix }}-*
+          merge-multiple: true
       - name: Import locally
         run: |
           # Unpack artifact

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - 6-22.04
-      - 5-22.04
   pull_request:
 jobs:
   build:
@@ -33,9 +32,6 @@ jobs:
 
       - name: Import locally
         run: |
-          full_version="$(cat rockcraft.yaml | yq .version)"
-          ls
-
           sudo rockcraft.skopeo   --insecure-policy \
               copy \
               oci-archive:charmed-mongodb_6.0.6-2_amd64.rock \

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -1,23 +1,18 @@
-name: trivy
+name: Trivy Security Scanner
 on:
   push:
     branches:
       - 6-22.04
       - 5-22.04
   pull_request:
-  workflow_call:
-    inputs:
-      branch:
-        type: string
-        default: ""
 jobs:
   build:
     name: Build rock
     uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v29.0.1
   scan:
-    name: Trivy scan and sbom generation
+    name: Trivy scan and SBOM Generation
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -26,15 +21,6 @@ jobs:
         run: |
           # rockcraft
           sudo snap install rockcraft --classic --edge
-
-          # docker
-          sudo snap install docker
-          sudo addgroup --system docker; sudo adduser $USER docker
-          newgrp docker
-          sudo snap disable docker; sudo snap enable docker
-
-          # skopeo
-          sudo snap install --devmode --channel edge skopeo
 
           # yq
           sudo snap install yq
@@ -56,7 +42,7 @@ jobs:
               docker-daemon:trivy/charmed-mongodb:test
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@master
         with:
           image-ref: "trivy/charmed-mongodb:test"
           format: "sarif"
@@ -68,10 +54,9 @@ jobs:
         if: always()
         with:
           sarif_file: "trivy-results.sarif"
-          ref: ${{ inputs.branch }}
 
       - name: Run Trivy in GitHub SBOM mode and submit results to Dependency Graph
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@master
         with:
           scan-type: "image"
           format: "spdx-json"

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -29,7 +29,8 @@ jobs:
       - name: Get Artifact Name
         id: artifact
         run: |
-          BASE_ARTIFACT=$(make help | grep 'Artifact: ')
+          sudo snap install yq
+          BASE_ARTIFACT="$(cat rockcraft.yaml | yq .name)"
           echo "base_artifact_name=${BASE_ARTIFACT#'Artifact: '}" >> $GITHUB_OUTPUT
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -52,7 +53,7 @@ jobs:
           severity: "MEDIUM,HIGH,CRITICAL"
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         if: always()
         with:
           sarif_file: "trivy-results.sarif"

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -12,27 +12,36 @@ on:
         default: ""
 jobs:
   build:
+    name: Build rock
     uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v29.0.1
   scan:
     name: Trivy scan and sbom generation
     needs: build
     runs-on: ubuntu-20.04
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.branch }}
+      - name: Checkout repo
+        uses: actions/checkout@v3
 
-      - name: Install snaps
+      - name: Install required dependencies
         run: |
-          sudo snap install rockcraft --classic --edge
+          # docker
+          sudo snap install docker
+          sudo addgroup --system docker; sudo adduser $USER docker
+          newgrp docker
+          sudo snap disable docker; sudo snap enable docker
+
+          # skopeo
           sudo snap install --devmode --channel edge skopeo
+
+          # yq
           sudo snap install yq
+
       - name: Download rock package(s)
         uses: actions/download-artifact@v4
         with:
           pattern: ${{ needs.build.outputs.artifact-prefix }}-*
           merge-multiple: true
+
       - name: Import locally
         run: |
           full_version="$(cat rockcraft.yaml | yq .version)"

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -4,6 +4,10 @@ on:
     branches:
       - 6-22.04
   pull_request:
+
+permissions:
+  contents: read # Set the GITHUB_TOKEN permissions to read-only
+
 jobs:
   build:
     name: Build rock
@@ -32,9 +36,10 @@ jobs:
 
       - name: Import locally
         run: |
+          full_version="$(cat rockcraft.yaml | yq .version)"
           sudo rockcraft.skopeo   --insecure-policy \
               copy \
-              oci-archive:charmed-mongodb_6.0.6-2_amd64.rock \
+              oci-archive:charmed-mongodb_${full_version}_amd64.rock \
               docker-daemon:trivy/charmed-mongodb:test
 
       - name: Run Trivy vulnerability scanner


### PR DESCRIPTION
# Issue

No SBOM generation or Code scanning is currently done for our rock

# Solution

Add this [based on Kafka](https://github.com/canonical/charmed-kafka-rock/blob/3-22.04/.github/workflows/trivy.yml)

# Code scanning results
[link to code scanning results](https://github.com/canonical/charmed-mongodb-rock/security/code-scanning?query=is%3Aopen+pr%3A45) note many are critical



Since snap is used in the rock, it is not strictly necessary to duplicate this work for snaps and take up more runners than necessary