### PR TITLE
feat(DPE-7747): New rock for 8-transition (#50)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,7 +11,7 @@ on:
   push:
     branches:
       - 6-22.04
-      - 8-transition-22.04
+      - 8-transition-24.04
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Fix a typo in branch name, which was referring to `8-transition-22.04` instead of `8-transition-24.04`