### PR TITLE
patch: add SECURITY.md file 

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security policy
+
+## What qualifies as a security issue
+
+Credentials leakage, outdated dependencies with known vulnerabilities, and
+other issues that could lead to unprivileged or unauthorised access to the
+database or the system.
+
+## Reporting a vulnerability
+
+The easiest way to report a security issue is through
+[Launchpad](https://wiki.ubuntu.com/DebuggingSecurity#How%20to%20File).
+
+The repository admins will be notified of the issue and will work with you
+to determine whether the issue qualifies as a security issue and, if so, in
+which component. We will then handle figuring out a fix, getting a CVE
+assigned and coordinating the release of the fix.
+
+The [Ubuntu Security disclosure and embargo
+policy](https://ubuntu.com/security/disclosure-policy) contains more
+information about what you can expect when you contact us, and what we
+expect from you.


### PR DESCRIPTION
Every Canonical owned repository must include a SECURITY.md file that outlines how users and contributors can report security issues. Teams must clearly define the product lifetime and support phases, specifying how long vulnerabilities will be addressed and under what conditions. It is acceptable for support periods to vary widely, but this must be well-documented and clearly communicated to users.