### PR TITLE
patch: bump workflow versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,4 +6,4 @@ on:
 jobs:
   build:
     name: Build rock
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v29.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v40.0.2

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -12,10 +12,10 @@ on:
 jobs:
   build:
     name: Build rock
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v29.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v40.0.2
 
   integration:
-    runs-on: [self-hosted, linux, X64, jammy, large]
+    runs-on: [self-hosted, linux, X64, noble, large]
     timeout-minutes: 120
     needs: build
     strategy:
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v40.0.2
 
   integration:
-    runs-on: [self-hosted, linux, X64, noble, large]
+    runs-on: [self-hosted, linux, X64, jammy, large]
     timeout-minutes: 120
     needs: build
     strategy:
@@ -29,11 +29,13 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: 1.32-strict/stable
-          microk8s-addons: "dns hostpath-storage"
+          channel: "1.29-strict/stable"
           bootstrap-constraints: "cores=2 mem=2G"
           juju-channel: 3.6/stable
-          charmcraft-channel: 3.x/stable
+          # This is needed until
+          # https://bugs.launchpad.net/juju/+bug/1977582 is fixed
+          bootstrap-options: "--agent-version 3.6.1"
+          charmcraft-channel: "latest/candidate"
       - name: Install rockcraft
         run: |
           sudo snap install rockcraft --classic

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -29,13 +29,11 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: "1.32-strict/stable"
+          channel: 1.32-strict/stable
+          microk8s-addons: "dns hostpath-storage rbac"
           bootstrap-constraints: "cores=2 mem=2G"
           juju-channel: 3.6/stable
-          # This is needed until
-          # https://bugs.launchpad.net/juju/+bug/1977582 is fixed
-          bootstrap-options: "--agent-version 3.6.1"
-          charmcraft-channel: "latest/candidate"
+          charmcraft-channel: 3.x/stable
       - name: Install rockcraft
         run: |
           sudo snap install rockcraft --classic

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           provider: microk8s
           channel: 1.32-strict/stable
-          microk8s-addons: "dns hostpath-storage rbac"
+          microk8s-addons: "dns hostpath-storage"
           bootstrap-constraints: "cores=2 mem=2G"
           juju-channel: 3.6/stable
           charmcraft-channel: 3.x/stable

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: "1.29-strict/stable"
+          channel: "1.32-strict/stable"
           bootstrap-constraints: "cores=2 mem=2G"
           juju-channel: 3.6/stable
           # This is needed until

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install tox
         run: python3 -m pip install tox
       - name: YAML Lint

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,13 +18,13 @@ on:
 jobs:
   build:
     name: Build rock
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v29.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v40.0.2
 
   publish:
     name: Release rock
     needs:
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_rock.yaml@v29.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/release_rock.yaml@v40.0.2
     with:
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
     permissions:

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -6,6 +6,7 @@ on:
       - 8-transition-24.04
       - 8-24.04
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:
@@ -42,7 +43,7 @@ jobs:
               docker-daemon:trivy/charmed-mongodb:test
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.33.1
         with:
           image-ref: "trivy/charmed-mongodb:test"
           format: "sarif"

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -57,7 +57,7 @@ jobs:
           sarif_file: "trivy-results.sarif"
 
       - name: Run Trivy in GitHub SBOM mode and submit results to Dependency Graph
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.33.1
         with:
           scan-type: "image"
           format: "spdx-json"

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -4,19 +4,20 @@ on:
     branches:
       - 6-22.04
       - 8-transition-24.04
+      - 8-24.04
   pull_request:
 
 jobs:
   build:
     name: Build rock
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v29.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v40.0.2
   scan:
     name: Trivy scan and SBOM Generation
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Install required dependencies
         run: |
@@ -27,7 +28,7 @@ jobs:
           sudo snap install yq
 
       - name: Download rock package(s)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: ${{ needs.build.outputs.artifact-prefix }}-*
           merge-multiple: true
@@ -49,7 +50,7 @@ jobs:
           severity: "MEDIUM,HIGH,CRITICAL"
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: "trivy-results.sarif"


### PR DESCRIPTION
This PR :
- bumps the build rock and release workflow version from `v29.0.1` to `v40.0.2`
- Adds the trivy workflow to the 8-24.04 branch and allows the workflow_dispatch