### PR TITLE
chore: Bump to 6.0.27-21 and other tools

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 name: charmed-mongodb # the name of your rock
 base: ubuntu@22.04 # the base environment for this rock
-version: "6.0.24-19" # just for humans. Semantic versioning is recommended
+version: "6.0.27-21" # just for humans. Semantic versioning is recommended
 summary: MongoDB in a rock. # 79 char long summary
 description: |
   MongoDB is a source-available cross-platform


### PR DESCRIPTION
* MongoDB 6.0.27-21
* PBM 2.10.0 (with go1.24)
* MongoDB Exporter 0.47.2 (with go1.24)


