### PR TITLE
feat: MongoDB 6.0.28-22

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,4 +6,7 @@ on:
 jobs:
   build:
     name: Build rock
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v40.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v41.0.0
+    permissions:
+      actions: read # Needed for GitHub API call to get workflow version
+      contents: read

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -12,7 +12,10 @@ on:
 jobs:
   build:
     name: Build rock
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v40.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v41.0.0
+    permissions:
+      actions: read # Needed for GitHub API call to get workflow version
+      contents: read
 
   integration:
     runs-on: [self-hosted, linux, X64, jammy, large]
@@ -22,6 +25,8 @@ jobs:
       matrix:
         env: [integration, sharding-integration]
       fail-fast: false
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,3 +20,5 @@ jobs:
         run: python3 -m pip install tox
       - name: YAML Lint
         run: tox -e lint
+    permissions:
+      contents: read

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,13 +16,16 @@ on:
 jobs:
   build:
     name: Build rock
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v40.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v41.0.0
+    permissions:
+      actions: read # Needed for GitHub API call to get workflow version
+      contents: read
 
   publish:
     name: Release rock
     needs:
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_rock.yaml@v40.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/release_rock.yaml@v41.0.0
     with:
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
     permissions:

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -9,11 +9,16 @@ on:
 jobs:
   build:
     name: Build rock
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v40.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v41.0.0
+    permissions:
+      actions: read # Needed for GitHub API call to get workflow version
+      contents: read
   scan:
     name: Trivy scan and SBOM Generation
     needs: build
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -27,7 +27,7 @@ parts:
     stage-snaps:
       - charmed-mongodb/6/edge
       - yq
-    overlay-packages:
+    stage-packages:
       - ca-certificates
       - libssh-4
       - libbrotli1

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 name: charmed-mongodb # the name of your rock
 base: ubuntu@22.04 # the base environment for this rock
-version: "6.0.27-21" # just for humans. Semantic versioning is recommended
+version: "6.0.28-22" # just for humans. Semantic versioning is recommended
 summary: MongoDB in a rock. # 79 char long summary
 description: |
   MongoDB is a source-available cross-platform

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -36,10 +36,9 @@ parts:
   non-root-user:
     plugin: nil
     after: [mongo-snap]
-    overlay-script: |
-      # Create a user in the $CRAFT_OVERLAY chroot
-      groupadd -R $CRAFT_OVERLAY -g  584788 mongodb
-      useradd -R $CRAFT_OVERLAY -M -r -g mongodb -u 584788 mongodb
+    override-overlay: |
+      groupadd -g  584788 mongodb
+      useradd -M -r -g mongodb -u 584788 mongodb
     override-prime: |
       craftctl default
 

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ commands =
 		cut -c 8-)_edge_amd64.rock --base-name {env:registry_namespace}/{env:name}'
 	bash -ec 'if ! [ -d operator ]; then git clone --single-branch --branch {env:branch} {env:repo} operator; fi' {posargs}
     bash -ec 'yq -r .version rockcraft.yaml | cut -d"-" -f1 > operator/workload_version'
+    bash -ec 'pushd operator; charmcraft pack; popd'
 	tox --workdir operator -c operator -e integration -- tests/integration/test_charm.py 
 
 [testenv:sharding-integration]
@@ -48,4 +49,5 @@ commands =
 		cut -c 8-)_edge_amd64.rock --base-name {env:registry_namespace}/{env:name}'
 	bash -ec 'if ! [ -d operator ]; then git clone --single-branch --branch {env:branch} {env:repo} operator; fi' {posargs}
     bash -ec 'yq -r .version rockcraft.yaml | cut -d"-" -f1 > operator/workload_version'
+    bash -ec 'pushd operator; charmcraft pack; popd'
 	tox --workdir operator -c operator -e integration -- tests/integration/test_sharding.py 


### PR DESCRIPTION
 * Fixes CVE-2026-8053
 * Bump Mongo Tools to 100.17.0

* Moves deps to  `stage-packages` from `overlay-packages` to woraround [a rockcraft issue](https://github.com/canonical/rockcraft/issues/1217)
* Use `override-overlay` instead of `overlay-script` to abide with newer rockcraft versions.