### PR TITLE
feat: MongoDB 7.0.34-19

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,4 +6,7 @@ on:
 jobs:
   build:
     name: Build rock
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v40.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v41.0.0
+    permissions:
+      actions: read # Needed for GitHub API call to get workflow version
+      contents: read

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: "1.29-strict/stable"
+          channel: "1.35-strict/stable"
           bootstrap-constraints: "cores=2 mem=2G"
           juju-channel: 3.6/stable
           charmcraft-channel: "latest/candidate"

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -12,7 +12,10 @@ on:
 jobs:
   build:
     name: Build rock
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v40.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v41.0.0
+    permissions:
+      actions: read # Needed for GitHub API call to get workflow version
+      contents: read
 
   integration:
     runs-on: [self-hosted, linux, X64, jammy, large]
@@ -22,6 +25,8 @@ jobs:
       matrix:
         env: [integration, sharding-integration]
       fail-fast: false
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -18,7 +18,7 @@ jobs:
       contents: read
 
   integration:
-    runs-on: [self-hosted, linux, X64, noble, large]
+    runs-on: self-hosted-linux-amd64-noble-medium
     timeout-minutes: 120
     needs: build
     strategy:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -18,7 +18,7 @@ jobs:
       contents: read
 
   integration:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     needs: build
     strategy:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -18,7 +18,7 @@ jobs:
       contents: read
 
   integration:
-    runs-on: self-hosted-linux-amd64-noble-medium
+    runs-on: ubuntu-latest
     timeout-minutes: 120
     needs: build
     strategy:
@@ -30,6 +30,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+      - name: Setup python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -48,14 +52,12 @@ jobs:
           merge-multiple: true
       - name: Install tox & poetry
         run: |
-          sudo apt-get update
-          sudo apt-get install python3-pip python3-venv -y --no-install-recommends
-          python3 -m pip install --user pipx
-          python3 -m pipx ensurepath
           pipx install tox
           pipx install poetry
           pipx install charmcraftcache
           pipx inject poetry poetry-plugin-export
+
+          $(pipx environment --value PIPX_BIN_DIR)/poetry env use $pythonLocation
       - name: Install yq
         run: |
           sudo snap install yq --classic

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -18,7 +18,7 @@ jobs:
       contents: read
 
   integration:
-    runs-on: [self-hosted, linux, X64, jammy, large]
+    runs-on: [self-hosted, linux, X64, noble, large]
     timeout-minutes: 120
     needs: build
     strategy:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -30,10 +30,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-      - name: Setup python 3.12
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -56,8 +52,6 @@ jobs:
           pipx install poetry
           pipx install charmcraftcache
           pipx inject poetry poetry-plugin-export
-
-          $(pipx environment --value PIPX_BIN_DIR)/poetry env use $pythonLocation
       - name: Install yq
         run: |
           sudo snap install yq --classic

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,3 +20,5 @@ jobs:
         run: python3 -m pip install tox
       - name: YAML Lint
         run: tox -e lint
+    permissions:
+      contents: read

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,15 +17,18 @@ on:
 jobs:
   build:
     name: Build rock
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v40.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v41.0.0
+    permissions:
+      actions: read # Needed for GitHub API call to get workflow version
+      contents: read
 
   publish:
     name: Release rock
     needs:
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_rock.yaml@v40.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/release_rock.yaml@v41.0.0
     with:
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
     permissions:
-      packages: write  # Needed to publish to GitHub Container Registry
-      contents: write  # Needed to create git tags
+      packages: write # Needed to publish to GitHub Container Registry
+      contents: write # Needed to create git tags

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -9,11 +9,16 @@ on:
 jobs:
   build:
     name: Build rock
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v40.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v41.0.0
+    permissions:
+      actions: read # Needed for GitHub API call to get workflow version
+      contents: read
   scan:
     name: Trivy scan and SBOM Generation
     needs: build
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -27,7 +27,7 @@ parts:
     stage-snaps:
       - charmed-mongodb/8-transition/edge
       - yq
-    overlay-packages:
+    stage-packages:
       - ca-certificates
       - libssh-4
       - libbrotli1

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 name: charmed-mongodb # the name of your rock
 base: ubuntu@24.04 # the base environment for this rock
-version: "7.0.28-15" # just for humans. Semantic versioning is recommended
+version: "7.0.34-19" # just for humans. Semantic versioning is recommended
 summary: MongoDB in a rock. # 79 char long summary
 description: |
   MongoDB is a source-available cross-platform

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -36,10 +36,9 @@ parts:
   non-root-user:
     plugin: nil
     after: [mongo-snap]
-    overlay-script: |
-      # Create a user in the $CRAFT_OVERLAY chroot
-      groupadd -R $CRAFT_OVERLAY -g  584788 mongodb
-      useradd -R $CRAFT_OVERLAY -M -r -g mongodb -u 584788 mongodb
+    override-overlay: |
+      groupadd -g  584788 mongodb
+      useradd -M -r -g mongodb -u 584788 mongodb
     override-prime: |
       craftctl default
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ allowlist_externals =
 	tox
 	bash
     yq
+    charmcraftcache
 commands = 
 	bash -ec 'if ! [ -f {env:name}_*-$(yq .base rockcraft.yaml | cut -c 8-)_edge_amd64.rock ]; \
 		then rockcraft pack; ./retag_rock.sh; fi'
@@ -34,7 +35,7 @@ commands =
 		cut -c 8-)_edge_amd64.rock --base-name {env:registry_namespace}/{env:name}'
 	bash -ec 'if ! [ -d operator ]; then git clone --single-branch --branch {env:branch} {env:repo} operator; fi' {posargs}
     bash -ec 'yq -r .version rockcraft.yaml | cut -d"-" -f1 > operator/workload_version'
-    bash -ec 'pushd operator; charmcraft pack; popd'
+    bash -ec 'pushd operator; charmcraftcache pack; popd'
 	tox --workdir operator -c operator -e integration -- tests/integration/test_charm.py 
 
 [testenv:sharding-integration]
@@ -44,6 +45,7 @@ allowlist_externals =
 	tox
 	bash
     yq
+    charmcraftcache
 pass_env =
     CI
 commands = 
@@ -53,5 +55,5 @@ commands =
 		cut -c 8-)_edge_amd64.rock --base-name {env:registry_namespace}/{env:name}'
 	bash -ec 'if ! [ -d operator ]; then git clone --single-branch --branch {env:branch} {env:repo} operator; fi' {posargs}
     bash -ec 'yq -r .version rockcraft.yaml | cut -d"-" -f1 > operator/workload_version'
-    bash -ec 'pushd operator; charmcraft pack; popd'
+    bash -ec 'pushd operator; charmcraftcache pack; popd'
 	tox --workdir operator -c operator -e integration -- tests/integration/test_sharding.py 

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ commands =
 		cut -c 8-)_edge_amd64.rock --base-name {env:registry_namespace}/{env:name}'
 	bash -ec 'if ! [ -d operator ]; then git clone --single-branch --branch {env:branch} {env:repo} operator; fi' {posargs}
     bash -ec 'yq -r .version rockcraft.yaml | cut -d"-" -f1 > operator/workload_version'
+    bash -ec 'pushd operator; charmcraft pack; popd'
 	tox --workdir operator -c operator -e integration -- tests/integration/test_charm.py 
 
 [testenv:sharding-integration]
@@ -48,4 +49,5 @@ commands =
 		cut -c 8-)_edge_amd64.rock --base-name {env:registry_namespace}/{env:name}'
 	bash -ec 'if ! [ -d operator ]; then git clone --single-branch --branch {env:branch} {env:repo} operator; fi' {posargs}
     bash -ec 'yq -r .version rockcraft.yaml | cut -d"-" -f1 > operator/workload_version'
+    bash -ec 'pushd operator; charmcraft pack; popd'
 	tox --workdir operator -c operator -e integration -- tests/integration/test_sharding.py 

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ setenv =
 	name=charmed-mongodb
 	registry_namespace=ghcr.io/canonical
 	repo=https://github.com/canonical/mongodb-k8s-operator.git
-	branch=6/edge
+	branch=8-transition/edge
 
 [testenv:lint]
 description = run linters

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,8 @@ commands =
 [testenv:integration]
 description = run operator integration tests
 skip_install = true
+pass_env =
+    CI
 allowlist_externals =
 	tox
 	bash
@@ -42,6 +44,8 @@ allowlist_externals =
 	tox
 	bash
     yq
+pass_env =
+    CI
 commands = 
 	bash -ec 'if ! [ -f {env:name}_*-$(yq .base rockcraft.yaml | cut -c 8-)_edge_amd64.rock ]; \
 		then rockcraft pack; ./retag_rock.sh; fi'


### PR DESCRIPTION
Fixes a bunch of upstream CVEs: 
 * CVE-2026-8053
 * CVE-2026-8199
 * CVE-2026-8336
 * CVE-2026-8202
 * CVE-2026-8200
* Bump Mongo Tools to 100.17.0


* Moves deps to  `stage-packages` from `overlay-packages` to woraround [a rockcraft issue](https://github.com/canonical/rockcraft/issues/1217)
* Use `override-overlay` instead of `overlay-script` to abide with newer rockcraft versions.