### PR TITLE
fix: ca-certificates is in overlay packages

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -27,8 +27,9 @@ parts:
     stage-snaps:
       - charmed-mongodb/6/edge
       - yq
-    stage-packages:
+    overlay-packages:
       - ca-certificates
+    stage-packages:
       - libssh-4
       - libbrotli1
       - logrotate


### PR DESCRIPTION
As stage-packages, the certificates do not appear in the right directory.
This was never an issue before for some reason, probably due to updated handling of the files coming from mongodb snap.

cf: https://github.com/canonical/rockcraft/issues/334